### PR TITLE
JDP200203-28 Niedozwolone słowo w nazwie encji Group

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -2,7 +2,7 @@ package com.kodilla.ecommercee.domain;
 
 import javax.persistence.*;
 
-@Entity(name = "groups")
+@Entity(name = "groups_of_products")
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
Encja group ma niedozwoloną nazwę "groups"
https://dev.mysql.com/doc/refman/8.0/en/keywords.html
Projekt się buduje, ale nie pozwala zapisać obiektów. Proponowana zmiana na "groups_of_products"
