### PR TITLE
JDP200203-30 Bug - przeniesienie klas Generic

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/ProductController.java
+++ b/src/main/java/com/kodilla/ecommercee/ProductController.java
@@ -1,5 +1,6 @@
 package com.kodilla.ecommercee;
 
+import com.kodilla.ecommercee.domain.GenericEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;

--- a/src/main/java/com/kodilla/ecommercee/domain/GenericEntity.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/GenericEntity.java
@@ -1,4 +1,4 @@
-package com.kodilla.ecommercee;
+package com.kodilla.ecommercee.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/kodilla/ecommercee/repository/GenericEntityRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/GenericEntityRepository.java
@@ -1,5 +1,6 @@
-package com.kodilla.ecommercee;
+package com.kodilla.ecommercee.repository;
 
+import com.kodilla.ecommercee.domain.GenericEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/test/java/com/kodilla/ecommercee/SpringBootJPAIntegrationTest.java
+++ b/src/test/java/com/kodilla/ecommercee/SpringBootJPAIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.kodilla.ecommercee;
 
+import com.kodilla.ecommercee.domain.GenericEntity;
+import com.kodilla.ecommercee.repository.GenericEntityRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Coś nie pykło przy przeniesieniu klas Generic do folderów (Entity, Repository, IntegrationTest) i nie zaktualizowały się właściwie nazwy paczek.