### PR TITLE
JDP200203-32 Utworzenie getProducts() w encji Cart

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/domain/Cart.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Cart.java
@@ -72,6 +72,10 @@ public class Cart {
         return user;
     }
 
+    public Map<Product, Integer> getProducts() {
+        return products;
+    }
+
     public void setId(Long id) {
         this.id = id;
     }


### PR DESCRIPTION
konieczność utworzenie gettera wynika z konieczności importowania zestawu produktów przypiętych do koszyka do zamówienia